### PR TITLE
fix: better genericizing

### DIFF
--- a/netlify/functions/makeCommentGenerationCall/index.ts
+++ b/netlify/functions/makeCommentGenerationCall/index.ts
@@ -32,7 +32,8 @@ const handler: Handler = async (
 			// 	: "") +
 			(options.lastComment
 				? `This is the final comment of the year, and should be in the past tense.`
-				: "");
+				: "") +
+			" Avoid the first person.";
 		const messages: Array<ChatCompletionRequestMessage> = [
 			{
 				role: "system",

--- a/src/utility/genericize.ts
+++ b/src/utility/genericize.ts
@@ -10,8 +10,15 @@ export const genericize = (
 ) => {
   let genericizedComment = comment;
   const replacements: Array<[RegExp, string]> = [
-    [/\ss?he\s/g, `{{he/she}}`],
-    [/\s(He)|(She)\s/g, `{{He/She}}`],
+    [/\ss?he\s/g, ` {{he/she}} `],
+    [/\sthey\s/g, " {{he/she}} "],
+    [/\stheir\s/g, " {{his/her}} "],
+    [/\sTheir\s/g, " {{His/her}} "],
+    [/\s(his)|(her)\s/g, " {{his/her}} "],
+    [/\s(His)|(Her)\s/g, " {{His/Her}} "],
+    [/\s(He)|(She)\s/g, ` {{He/She}} `],
+    [/\sThey\s/g, ` {{He/She}} `],
+    [/\s+/g, " "],
   ];
   if (options.name) {
     const { name } = options;


### PR DESCRIPTION
The function to 'genericize' the comment (e.g. 'he' -> '{{he/she}}') now accounts for more cases.

Closes #24